### PR TITLE
unwrapOrThrow メソッドの実装

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -6,6 +6,7 @@ namespace WizDevelop\PhpMonad;
 
 use Closure;
 use RuntimeException;
+use Throwable;
 
 /**
  * Option monad as a `Maybe monad`.
@@ -61,6 +62,16 @@ interface Option extends Monad
      * @return T|U
      */
     public function unwrapOrElse(Closure $default): mixed;
+
+    /**
+     * Returns the contained Some value or throws the provided exception.
+     *
+     * @template E of \Throwable
+     * @param  E $exception The exception to throw if the option is None
+     * @return T
+     * @throws E
+     */
+    public function unwrapOrThrow(Throwable $exception): mixed;
 
     /**
      * @see https://doc.rust-lang.org/std/option/enum.Option.html#method.inspect

--- a/src/Option/None.php
+++ b/src/Option/None.php
@@ -8,6 +8,7 @@ use Closure;
 use EmptyIterator;
 use Override;
 use RuntimeException;
+use Throwable;
 use Traversable;
 use WizDevelop\PhpMonad\Option;
 use WizDevelop\PhpMonad\Result;
@@ -84,6 +85,17 @@ enum None implements Option
     public function unwrapOrElse(Closure $default): mixed
     {
         return $default();
+    }
+
+    /**
+     * @template E of \Throwable
+     * @param  E $exception
+     * @throws E
+     */
+    #[Override]
+    public function unwrapOrThrow(Throwable $exception): never
+    {
+        throw $exception;
     }
 
     /**

--- a/src/Option/Some.php
+++ b/src/Option/Some.php
@@ -6,6 +6,7 @@ namespace WizDevelop\PhpMonad\Option;
 
 use Closure;
 use Override;
+use Throwable;
 use Traversable;
 use WizDevelop\PhpMonad\Option;
 use WizDevelop\PhpMonad\Result;
@@ -96,6 +97,18 @@ final readonly class Some implements Option
      */
     #[Override]
     public function unwrapOrElse(Closure $default): mixed
+    {
+        return $this->value;
+    }
+
+    /**
+     * @template E of \Throwable
+     * @param  E     $exception
+     * @return T
+     * @throws never
+     */
+    #[Override]
+    public function unwrapOrThrow(Throwable $exception): mixed
     {
         return $this->value;
     }

--- a/src/Result.php
+++ b/src/Result.php
@@ -78,6 +78,16 @@ interface Result extends Monad
     public function unwrapOrElse(Closure $default): mixed;
 
     /**
+     * Returns the contained Ok value or throws the provided exception.
+     *
+     * @template F of \Throwable
+     * @param  F $exception The exception to throw if the result is Err
+     * @return T
+     * @throws F
+     */
+    public function unwrapOrThrow(Throwable $exception): mixed;
+
+    /**
      * @see https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect
      * @param  Closure(T) :mixed $callback
      * @return $this

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -132,6 +132,17 @@ final readonly class Err implements Result
     }
 
     /**
+     * @template F of \Throwable
+     * @param  F $exception
+     * @throws F
+     */
+    #[Override]
+    public function unwrapOrThrow(Throwable $exception): never
+    {
+        throw $exception;
+    }
+
+    /**
      * @return $this
      */
     #[Override]

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -7,6 +7,7 @@ namespace WizDevelop\PhpMonad\Result;
 use Closure;
 use Override;
 use RuntimeException;
+use Throwable;
 use Traversable;
 use WizDevelop\PhpMonad\Option;
 use WizDevelop\PhpMonad\Result;
@@ -110,6 +111,18 @@ final readonly class Ok implements Result
 
     #[Override]
     public function unwrapOrElse(Closure $default): mixed
+    {
+        return $this->value;
+    }
+
+    /**
+     * @template F of \Throwable
+     * @param  F     $exception
+     * @return T
+     * @throws never
+     */
+    #[Override]
+    public function unwrapOrThrow(Throwable $exception): mixed
     {
         return $this->value;
     }

--- a/tests/Unit/Option/UnwrapOrThrowTest.php
+++ b/tests/Unit/Option/UnwrapOrThrowTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WizDevelop\PhpMonad\Tests\Unit\Option;
+
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use WizDevelop\PhpMonad\Option;
+
+use function WizDevelop\PhpMonad\Option\none;
+use function WizDevelop\PhpMonad\Option\some;
+
+#[TestDox('Option - UnwrapOrThrowTest')]
+#[CoversClass(Option::class)]
+final class UnwrapOrThrowTest extends TestCase
+{
+    #[Test]
+    #[TestDox('some値の場合は値を返す')]
+    public function some値の場合は値を返す(): void
+    {
+        $value = 'test';
+        $option = some($value);
+        $exception = new Exception('This exception should not be thrown');
+
+        $this->assertSame($value, $option->unwrapOrThrow($exception));
+    }
+
+    #[Test]
+    #[TestDox('none値の場合は指定した例外をスローする')]
+    public function none値の場合は指定した例外をスローする(): void
+    {
+        $option = none();
+        $message = 'Custom exception message';
+        $exception = new RuntimeException($message);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($message);
+
+        $option->unwrapOrThrow($exception);
+    }
+
+    #[Test]
+    #[TestDox('none値の場合はカスタム例外をスローできる')]
+    public function none値の場合はカスタム例外をスローできる(): void
+    {
+        $option = none();
+        $customException = new class ('Custom exception') extends Exception {
+        };
+
+        $this->expectException($customException::class);
+        $this->expectExceptionMessage('Custom exception');
+
+        $option->unwrapOrThrow($customException);
+    }
+}

--- a/tests/Unit/Result/UnwrapOrThrowTest.php
+++ b/tests/Unit/Result/UnwrapOrThrowTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WizDevelop\PhpMonad\Tests\Unit\Result;
+
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use WizDevelop\PhpMonad\Result;
+
+use function WizDevelop\PhpMonad\Result\err;
+use function WizDevelop\PhpMonad\Result\ok;
+
+#[TestDox('Option - UnwrapOrThrowTest')]
+#[CoversClass(Result::class)]
+final class UnwrapOrThrowTest extends TestCase
+{
+    #[Test]
+    #[TestDox('ok値の場合は値を返す')]
+    public function ok値の場合は値を返す(): void
+    {
+        $value = 'test';
+        $result = ok($value);
+        $exception = new Exception('This exception should not be thrown');
+
+        $this->assertSame($value, $result->unwrapOrThrow($exception));
+    }
+
+    #[Test]
+    #[TestDox('err値の場合は指定した例外をスローする')]
+    public function err値の場合は指定した例外をスローする(): void
+    {
+        $result = err('error value');
+        $message = 'Custom exception message';
+        $exception = new RuntimeException($message);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($message);
+
+        $result->unwrapOrThrow($exception);
+    }
+
+    #[Test]
+    #[TestDox('err値の場合はカスタム例外をスローできる')]
+    public function err値の場合はカスタム例外をスローできる(): void
+    {
+        $result = err('error value');
+        $customException = new class ('Custom exception') extends Exception {
+        };
+
+        $this->expectException($customException::class);
+        $this->expectExceptionMessage('Custom exception');
+
+        $result->unwrapOrThrow($customException);
+    }
+}


### PR DESCRIPTION
## 概要
Option と Result クラスに `unwrapOrThrow()` メソッドを実装しました。

## 変更内容
- Option クラスに `unwrapOrThrow()` メソッドを実装
- Result クラスに `unwrapOrThrow()` メソッドを実装
- テストコードの実装

## 動作内容
- Some/Ok の場合：含まれる値を返します
- None/Err の場合：指定された例外をスローします

close #16