### PR TITLE
Add orThrow method to Result and Option

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -113,6 +113,16 @@ interface Option extends Monad
     public function orElse(Closure $right): self;
 
     /**
+     * Returns the contained Ok value or throws the provided exception.
+     *
+     * @template F of \Throwable
+     * @param  F     $exception The exception to throw if the result is Err
+     * @return $this
+     * @throws F
+     */
+    public function orThrow(Throwable $exception): self;
+
+    /**
      * @see https://doc.rust-lang.org/std/option/enum.Option.html#method.xor
      * @param  Option<T> $right
      * @return Option<T>

--- a/src/Option/None.php
+++ b/src/Option/None.php
@@ -128,6 +128,17 @@ enum None implements Option
         return $right();
     }
 
+    /**
+     * @template F of \Throwable
+     * @param  F $exception
+     * @throws F
+     */
+    #[Override]
+    public function orThrow(Throwable $exception): never
+    {
+        throw $exception;
+    }
+
     #[Override]
     public function xor(Option $right): Option
     {

--- a/src/Option/Some.php
+++ b/src/Option/Some.php
@@ -145,6 +145,17 @@ final readonly class Some implements Option
         return $this;
     }
 
+    /**
+     * @template F of \Throwable
+     * @return $this
+     * @throws never
+     */
+    #[Override]
+    public function orThrow(Throwable $exception): self
+    {
+        return $this;
+    }
+
     #[Override]
     public function xor(Option $right): Option
     {

--- a/src/Result.php
+++ b/src/Result.php
@@ -136,6 +136,16 @@ interface Result extends Monad
     public function orElse(Closure $right): self;
 
     /**
+     * Returns the contained Ok value or throws the provided exception.
+     *
+     * @template F of \Throwable
+     * @param  F     $exception The exception to throw if the result is Err
+     * @return $this
+     * @throws F
+     */
+    public function orThrow(Throwable $exception): self;
+
+    /**
      * @see https://doc.rust-lang.org/std/result/enum.Result.html#method.map
      * @template U
      * @param  Closure(T) :U $callback

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -184,6 +184,16 @@ final readonly class Err implements Result
     }
 
     /**
+     * @template F of \Throwable
+     * @throws F
+     */
+    #[Override]
+    public function orThrow(Throwable $exception): never
+    {
+        throw $exception;
+    }
+
+    /**
      * @return $this
      */
     #[Override]

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -172,6 +172,17 @@ final readonly class Ok implements Result
     }
 
     /**
+     * @template F of \Throwable
+     * @return $this
+     * @throws never
+     */
+    #[Override]
+    public function orThrow(Throwable $exception): self
+    {
+        return $this;
+    }
+
+    /**
      * @template U
      * @param  Closure(T) :U $callback
      * @return self<U>

--- a/tests/Unit/Option/OrThrowTest.php
+++ b/tests/Unit/Option/OrThrowTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WizDevelop\PhpMonad\Tests\Unit\Option;
+
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use RuntimeException;
+use WizDevelop\PhpMonad\Option;
+use WizDevelop\PhpMonad\Tests\TestCase;
+
+#[TestDox('Option - OrThrow メソッドのテスト')]
+#[CoversClass(Option::class)]
+#[CoversClass(Option\Some::class)]
+#[CoversClass(Option\None::class)]
+final class OrThrowTest extends TestCase
+{
+    #[Test]
+    #[TestDox('Some型の場合は例外を投げずそのインスタンスを返す')]
+    public function someReturnsItself(): void
+    {
+        $some = Option\some(42);
+        $exception = new RuntimeException('This exception should not be thrown');
+
+        $result = $some->orThrow($exception);
+
+        $this->assertSame($some, $result);
+        $this->assertTrue($result->isSome());
+        $this->assertSame(42, $result->unwrap());
+    }
+
+    #[Test]
+    #[TestDox('None型の場合は指定された例外を投げる')]
+    public function noneThrowsException(): void
+    {
+        $none = Option\none();
+        $exception = new RuntimeException('エラーが投げられました');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('エラーが投げられました');
+
+        $none->orThrow($exception);
+    }
+
+    #[Test]
+    #[TestDox('None型の場合は指定された任意のThrowableを投げる')]
+    public function noneThrowsCustomException(): void
+    {
+        $none = Option\none();
+        $exception = new Exception('カスタム例外が投げられました');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('カスタム例外が投げられました');
+
+        $none->orThrow($exception);
+    }
+}

--- a/tests/Unit/Result/OrThrowTest.php
+++ b/tests/Unit/Result/OrThrowTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WizDevelop\PhpMonad\Tests\Unit\Result;
+
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use RuntimeException;
+use WizDevelop\PhpMonad\Result;
+use WizDevelop\PhpMonad\Tests\TestCase;
+
+#[TestDox('Result - OrThrow メソッドのテスト')]
+#[CoversClass(Result::class)]
+#[CoversClass(Result\Ok::class)]
+#[CoversClass(Result\Err::class)]
+final class OrThrowTest extends TestCase
+{
+    #[Test]
+    #[TestDox('Ok型の場合は例外を投げずそのインスタンスを返す')]
+    public function okReturnsItself(): void
+    {
+        $ok = Result\ok(42);
+        $exception = new RuntimeException('This exception should not be thrown');
+
+        $result = $ok->orThrow($exception);
+
+        $this->assertSame($ok, $result);
+        $this->assertTrue($result->isOk());
+        $this->assertSame(42, $result->unwrap());
+    }
+
+    #[Test]
+    #[TestDox('Err型の場合は指定された例外を投げる')]
+    public function errThrowsException(): void
+    {
+        $err = Result\err('エラーが発生しました');
+        $exception = new RuntimeException('エラーが投げられました');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('エラーが投げられました');
+
+        $err->orThrow($exception);
+    }
+
+    #[Test]
+    #[TestDox('Err型の場合は指定された任意のThrowableを投げる')]
+    public function errThrowsCustomException(): void
+    {
+        $err = Result\err('エラーが発生しました');
+        $exception = new Exception('カスタム例外が投げられました');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('カスタム例外が投げられました');
+
+        $err->orThrow($exception);
+    }
+}


### PR DESCRIPTION
## 概要

ResultとOptionに`orThrow`メソッドを追加する実装です。

Closes #18

## 変更内容

- ResultとOptionインターフェースに`orThrow`メソッドを追加
- OkとErrクラスに実装を追加
- SomeとNoneクラスに実装を追加
- テストケースの追加

## テスト結果

すべてのテストが正常に通過することを確認済みです：
- Result
  - Ok型の場合は例外を投げずそのインスタンスを返す
  - Err型の場合は指定された例外を投げる
  - Err型の場合は指定された任意のThrowableを投げる

- Option
  - Some型の場合は例外を投げずそのインスタンスを返す
  - None型の場合は指定された例外を投げる
  - None型の場合は指定された任意のThrowableを投げる

## レビューポイント

- 型の定義が適切か
- テストケースが十分かどうか
- PHPDocの記述が適切か

## その他

- テストカバレッジは100%を維持しています
- PHPStanのLevel 8をパスしています