### PR TITLE
gitが入っていない環境でcomposer intallすると git was not found in your PATH, skipping source download エラーが発生する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,19 +31,5 @@
         "phpstan/phpstan": "^1.12",
         "phpunit/php-code-coverage": "^11.0",
         "phpunit/phpunit": "^11.3"
-    },
-    "archive": {
-        "exclude": [
-            "/.devcontainer",
-            "/.github",
-            "/.vscode",
-            "/tests",
-            "/.clineignore",
-            "/.clinerules",
-            "/.gitignore",
-            "/.php-cs-fixer.dist.php",
-            "/phpstan.neon.dist",
-            "/phpunit.xml.dist"
-        ]
     }
 }


### PR DESCRIPTION
Fixes #24