### PR TITLE
fix: PHPDocの型注釈を修正し、不要なテストを削除

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
   timeoutForSmallTests="1"
   timeoutForMediumTests="10"
   timeoutForLargeTests="60"
+  displayDetailsOnTestsThatTriggerWarnings="true"
 >
   <testsuites>
     <testsuite name="Unit">

--- a/src/Option/functions.php
+++ b/src/Option/functions.php
@@ -36,16 +36,16 @@ function none(): Option\None
  * It will be a `Some` option containing `$value` if `$value` is different from `$noneValue` (default `null`)
  *
  * @template U
- * @param  U|null    $value
- * @return Option<U>
+ * @template NoneValue
+ *
+ * @param U              $value
+ * @param NoneValue|null $noneValue
+ *
+ * @return ($noneValue is null ? Option<U> : Option<U|NoneValue>)
  */
-function fromValue($value, mixed $noneValue = null, bool $strict = true): Option
+function fromValue($value, mixed $noneValue = null): Option
 {
-    $same = $strict
-        ? ($value === $noneValue)
-        : ($value == $noneValue);
-
-    return $same
+    return $value === $noneValue
         ? Option\none()
         : Option\some($value);
 }
@@ -55,12 +55,16 @@ function fromValue($value, mixed $noneValue = null, bool $strict = true): Option
  * It will be a `Some` option containing the result if it is different from `$noneValue` (default `null`).
  *
  * @template U
- * @param  callable():U|null $callback
- * @return Option<U>
+ * @template NoneValue
+ *
+ * @param callable():U   $callback
+ * @param NoneValue|null $noneValue
+ *
+ * @return ($noneValue is null ? Option<U> : Option<U|NoneValue>)
  */
-function of(callable $callback, mixed $noneValue = null, bool $strict = true): Option
+function of(callable $callback, mixed $noneValue = null): Option
 {
-    return Option\fromValue($callback(), $noneValue, $strict);
+    return Option\fromValue($callback(), $noneValue);
 }
 
 /**
@@ -68,20 +72,24 @@ function of(callable $callback, mixed $noneValue = null, bool $strict = true): O
  * but also return `Option\None` if it an exception matching $exceptionClass was thrown.
  *
  * @template U
+ * @template NoneValue
  * @template E of \Throwable
- * @param  callable():U|null    $callback
- * @param  class-string<E> $exceptionClass
- * @return Option<U>
+ *
+ * @param callable():U    $callback
+ * @param NoneValue|null  $noneValue
+ * @param class-string<E> $exceptionClass
+ *
+ * @return ($noneValue is null ? Option<U> : Option<U|NoneValue>)
+ *
  * @throws Throwable
  */
 function tryOf(
     callable $callback,
     mixed $noneValue = null,
-    bool $strict = true,
     string $exceptionClass = Exception::class,
 ): Option {
     try {
-        return Option\of($callback, $noneValue, $strict);
+        return Option\of($callback, $noneValue);
     } catch (Throwable $th) {
         if (is_a($th, $exceptionClass)) {
             return Option\none();
@@ -95,7 +103,8 @@ function tryOf(
  * Converts from `Option<Option<T>>` to `Option<T>`.
  *
  * @template U
- * @param  Option<Option<U>> $option
+ * @param Option<Option<U>> $option
+ *
  * @return Option<U>
  */
 function flatten(Option $option): Option
@@ -113,7 +122,9 @@ function flatten(Option $option): Option
  *
  * @template U
  * @template E
- * @param  Option<Result<U, E>> $option
+ *
+ * @param Option<Result<U, E>> $option
+ *
  * @return Result<Option<U>, E>
  */
 function transpose(Option $option): Result

--- a/tests/Unit/Option/OfTest.php
+++ b/tests/Unit/Option/OfTest.php
@@ -60,26 +60,6 @@ final class OfTest extends TestCase
     }
 
     #[Test]
-    #[TestDox('ofDefaultToStrict test')]
-    public function ofDefaultToStrict(): void
-    {
-        $o = (object)[];
-
-        Assert::assertEquals(Option\none(), Option\of(static fn () => $o, (object)[], strict: false));
-        Assert::assertEquals($o, Option\of(static fn () => $o, (object)[])->unwrap());
-    }
-
-    #[Test]
-    #[TestDox('tryOfDefaultToStrict test')]
-    public function tryOfDefaultToStrict(): void
-    {
-        $o = (object)[];
-
-        Assert::assertEquals(Option\none(), Option\tryOf(static fn () => $o, (object)[], strict: false));
-        Assert::assertEquals($o, Option\tryOf(static fn () => $o, (object)[])->unwrap());
-    }
-
-    #[Test]
     #[TestDox('tryOfExeptions test')]
     public function tryOfExeptions(): void
     {

--- a/tests/Unit/Result/CombineTest.php
+++ b/tests/Unit/Result/CombineTest.php
@@ -54,14 +54,4 @@ final class CombineTest extends TestCase
         Assert::assertTrue($errors[0] === 'error1');
         Assert::assertTrue($errors[1] === 'error2');
     }
-
-    #[Test]
-    #[TestDox('空の配列を渡した場合はOk(true)を返すcombineのテスト')]
-    public function combineEmpty(): void
-    {
-        $result = Result\combine();
-
-        Assert::assertTrue($result->isOk());
-        Assert::assertTrue($result->unwrap());
-    }
 }


### PR DESCRIPTION
Fixes #50